### PR TITLE
Highlight keywords broken on word boundaries

### DIFF
--- a/syntax/lobster.vim
+++ b/syntax/lobster.vim
@@ -51,7 +51,7 @@ hi def link    lobsterIdentifier    lobsterBoolean
 " Operators
 
 " the wordy ones
-syn match lobsterOperator /is\|not\|and\|or/
+syn match lobsterOperator /\<(is\|not\|and\|or)\>/
 
 " match single-char operators:          - + * % < > ! =
 " and corresponding two-char operators: -= += %= <= >= != &= |= ^= *= ==


### PR DESCRIPTION
This change prevents keywords like “or” from being highlighted inside non-keywords like “keywords”.